### PR TITLE
fix(config): read `coverageDirectory` option from Jest config

### DIFF
--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -3,7 +3,6 @@ const fs = require('fs')
 const getData = require('../getData')
 
 const configPath = './jest.config.js'
-const reportPath = './coverage/coverage-summary.json'
 
 const reportContents = JSON.stringify({
   total: {
@@ -15,6 +14,7 @@ const reportContents = JSON.stringify({
 })
 
 jest.mock('fs')
+jest.spyOn(process, 'cwd').mockImplementation(() => '/workingDir')
 
 jest.mock(
   '../jest.config.js',
@@ -35,11 +35,39 @@ beforeAll(() => {
   fs.readFileSync.mockReturnValue(reportContents)
 })
 
-it('returns parsed config and report contents', () => {
-  const data = getData(configPath, reportPath)
+it('returns parsed config and report contents when no coverage directory is specified in the jest config', () => {
+  const data = getData(configPath)
 
   expect(fs.readFileSync).toHaveBeenCalledTimes(1)
-  expect(fs.readFileSync).toHaveBeenCalledWith(reportPath, 'utf8')
+  expect(fs.readFileSync).toHaveBeenCalledWith(
+    '/workingDir/coverage/coverage-summary.json',
+    'utf8',
+  )
+  expect(data).toStrictEqual({
+    coverages: {
+      branches: { pct: 80 },
+      functions: { pct: 70 },
+      lines: { pct: 60 },
+      statements: { pct: 50 },
+    },
+    thresholds: {
+      branches: 10,
+      functions: 20,
+      lines: 30,
+      statements: 40,
+    },
+  })
+})
+
+it('returns parsed config and report contents when a custom coverage directory is specified in the jest config', () => {
+  require('../jest.config.js').coverageDirectory = 'custom/coverage/directory'
+  const data = getData(configPath)
+
+  expect(fs.readFileSync).toHaveBeenCalledTimes(1)
+  expect(fs.readFileSync).toHaveBeenCalledWith(
+    '/workingDir/custom/coverage/directory/coverage-summary.json',
+    'utf8',
+  )
   expect(data).toStrictEqual({
     coverages: {
       branches: { pct: 80 },

--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -60,7 +60,9 @@ it('returns parsed config and report contents when no coverage directory is spec
 })
 
 it('returns parsed config and report contents when a custom coverage directory is specified in the jest config', () => {
-  require('../jest.config.js').coverageDirectory = 'custom/coverage/directory'
+  const config = require('../jest.config.js')
+  const { coverageDirectory: defaultCovergeDirectory } = config
+  config.coverageDirectory = 'custom/coverage/directory'
   const data = getData(configPath)
 
   expect(fs.readFileSync).toHaveBeenCalledTimes(1)
@@ -82,4 +84,5 @@ it('returns parsed config and report contents when a custom coverage directory i
       statements: 40,
     },
   })
+  config.coverageDirectory = defaultCovergeDirectory
 })

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -31,10 +31,7 @@ it('runs with with default options', async () => {
   await jestItUp()
 
   expect(getData).toHaveBeenCalledTimes(1)
-  expect(getData).toHaveBeenCalledWith(
-    '/workingDir/jest.config.js',
-    '/workingDir/coverage/coverage-summary.json',
-  )
+  expect(getData).toHaveBeenCalledWith('/workingDir/jest.config.js')
 
   expect(getNewThresholds).toHaveBeenCalledTimes(1)
   expect(getNewThresholds).toHaveBeenCalledWith('thresholds', 'coverages', 0)

--- a/lib/getData.js
+++ b/lib/getData.js
@@ -4,11 +4,11 @@ const path = require('path')
 const getData = configPath => {
   const {
     coverageThreshold: { global: thresholds },
-    coverageDirectory,
+    coverageDirectory = 'coverage',
   } = require(configPath)
-  const reportPath = path.join(
+  const reportPath = path.resolve(
     process.cwd(),
-    coverageDirectory || 'coverage',
+    coverageDirectory,
     'coverage-summary.json',
   )
   const { total: coverages } = JSON.parse(fs.readFileSync(reportPath, 'utf8'))

--- a/lib/getData.js
+++ b/lib/getData.js
@@ -1,9 +1,16 @@
 const fs = require('fs')
+const path = require('path')
 
-const getData = (configPath, reportPath) => {
+const getData = configPath => {
   const {
     coverageThreshold: { global: thresholds },
+    coverageDirectory,
   } = require(configPath)
+  const reportPath = path.join(
+    process.cwd(),
+    coverageDirectory || 'coverage',
+    'coverage-summary.json',
+  )
   const { total: coverages } = JSON.parse(fs.readFileSync(reportPath, 'utf8'))
 
   return { thresholds, coverages }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,9 +17,8 @@ module.exports = async ({
 } = {}) => {
   const workingDir = process.cwd()
   const configPath = path.resolve(workingDir, 'jest.config.js')
-  const reportPath = path.resolve(workingDir, 'coverage/coverage-summary.json')
 
-  const { thresholds, coverages } = getData(configPath, reportPath)
+  const { thresholds, coverages } = getData(configPath)
   const newThresholds = getNewThresholds(thresholds, coverages, margin)
   const { changes, data } = getChanges(configPath, newThresholds)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,8 +15,7 @@ module.exports = async ({
   margin = 0,
   silent = false,
 } = {}) => {
-  const workingDir = process.cwd()
-  const configPath = path.resolve(workingDir, 'jest.config.js')
+  const configPath = path.resolve(process.cwd(), 'jest.config.js')
 
   const { thresholds, coverages } = getData(configPath)
   const newThresholds = getNewThresholds(thresholds, coverages, margin)


### PR DESCRIPTION
Fixes #4 

Read coverage directory path from the jest config when provided, defaulting to `coverage/`. 