### PR TITLE
feat(config): add -c, --config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ $ jest-it-up --help
 Usage: jest-it-up [options]
 
 Options:
+  -c, --config <path>    path to a Jest config file (default: 'jest.config.js')
   -m, --margin <margin>  minimum threshold increase (default: 0)
   -i, --interactive      ask for confirmation before applying changes
   -s, --silent           do not output messages
   -d, --dry-run          process but do not change files
-  -c, --config <path>    the path to a Jest config file
   -v, --version          output the version number
   -h, --help             display help for command
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Options:
   -i, --interactive      ask for confirmation before applying changes
   -s, --silent           do not output messages
   -d, --dry-run          process but do not change files
+  -c, --config <path>    the path to a Jest config file
   -v, --version          output the version number
   -h, --help             display help for command
 ```

--- a/bin/jest-it-up
+++ b/bin/jest-it-up
@@ -5,11 +5,11 @@ const { version } = require('../package.json')
 const jestItUp = require('../lib')
 
 program
+  .option('-c, --config <path>', 'path to a Jest config file', 'jest.config.js')
   .option('-m, --margin <margin>', 'minimum threshold increase', parseFloat, 0)
   .option('-i, --interactive', 'ask for confirmation before applying changes')
   .option('-s, --silent', 'do not output messages')
   .option('-d, --dry-run', 'process but do not change files')
-  .option('-c, --config <path>', 'the path to a Jest config file')
   .version(version, '-v, --version')
   .parse(process.argv)
 

--- a/bin/jest-it-up
+++ b/bin/jest-it-up
@@ -9,6 +9,7 @@ program
   .option('-i, --interactive', 'ask for confirmation before applying changes')
   .option('-s, --silent', 'do not output messages')
   .option('-d, --dry-run', 'process but do not change files')
+  .option('-c, --config <path>', 'the path to a Jest config file')
   .version(version, '-v, --version')
   .parse(process.argv)
 

--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -22,10 +22,12 @@ const reportContents = JSON.stringify({
 })
 
 jest.mock('fs')
-jest.spyOn(path, 'dirname').mockImplementation(() => '/workingDir')
 
 beforeAll(() => fs.readFileSync.mockReturnValue(reportContents))
-beforeEach(() => jest.resetModules())
+beforeEach(() => {
+  jest.resetModules()
+  jest.spyOn(path, 'dirname').mockReturnValueOnce('/workingDir')
+})
 
 it('returns parsed config and report contents', async () => {
   jest.mock('../jest.config.js', () => ({ coverageThreshold }), {

--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const path = require('path')
 
 const getData = require('../getData')
 
@@ -21,7 +22,7 @@ const reportContents = JSON.stringify({
 })
 
 jest.mock('fs')
-jest.spyOn(process, 'cwd').mockImplementation(() => '/workingDir')
+jest.spyOn(path, 'dirname').mockImplementation(() => '/workingDir')
 
 beforeAll(() => fs.readFileSync.mockReturnValue(reportContents))
 beforeEach(() => jest.resetModules())

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -52,7 +52,7 @@ it('runs with with default options', async () => {
   )
 
   expect(outputResult).toHaveBeenCalledTimes(1)
-  expect(outputResult).toHaveBeenCalledWith(false)
+  expect(outputResult).toHaveBeenCalledWith('/workingDir/jest.config.js', false)
 })
 
 it('returns early if there are no changes', async () => {
@@ -89,7 +89,10 @@ it.each([true, false])(
       )
 
       expect(outputResult).toHaveBeenCalledTimes(1)
-      expect(outputResult).toHaveBeenCalledWith(false)
+      expect(outputResult).toHaveBeenCalledWith(
+        '/workingDir/jest.config.js',
+        false,
+      )
     } else {
       expect(applyChanges).not.toHaveBeenCalled()
       expect(outputResult).not.toHaveBeenCalled()
@@ -112,5 +115,5 @@ it('runs in dry-run mode', async () => {
   expect(applyChanges).not.toHaveBeenCalled()
 
   expect(outputResult).toHaveBeenCalledTimes(1)
-  expect(outputResult).toHaveBeenCalledWith(true)
+  expect(outputResult).toHaveBeenCalledWith('/workingDir/jest.config.js', true)
 })

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -117,3 +117,10 @@ it('runs in dry-run mode', async () => {
   expect(outputResult).toHaveBeenCalledTimes(1)
   expect(outputResult).toHaveBeenCalledWith('/workingDir/jest.config.js', true)
 })
+
+it('runs with custom config', async () => {
+  await jestItUp({ config: './customDir/jest.config.js' })
+
+  expect(getData).toHaveBeenCalledTimes(1)
+  expect(getData).toHaveBeenCalledWith('/workingDir/customDir/jest.config.js')
+})

--- a/lib/__tests__/outputResult.test.js
+++ b/lib/__tests__/outputResult.test.js
@@ -2,6 +2,7 @@ require('ansi-colors').enabled = false
 
 const outputResult = require('../outputResult')
 
+const configPath = './jest.config.js'
 const lines = []
 
 jest.spyOn(console, 'log').mockImplementation(message => lines.push(message))
@@ -11,17 +12,17 @@ afterEach(() => {
 })
 
 it('output results for updated coverage thresholds', () => {
-  outputResult(false)
+  outputResult(configPath, false)
 
   expect(lines.join('\n')).toMatchInlineSnapshot(
-    `"Done! Please record the changes to jest.config.js."`,
+    `"Done! Please record the changes to ${configPath}."`,
   )
 })
 
 it('output results in dry-run mode', () => {
-  outputResult(true)
+  outputResult(configPath, true)
 
   expect(lines.join('\n')).toMatchInlineSnapshot(
-    `"No changes made to jest.config.js. (dry-run mode)"`,
+    `"No changes made to ${configPath}. (dry-run mode)"`,
   )
 })

--- a/lib/getData.js
+++ b/lib/getData.js
@@ -8,7 +8,7 @@ const getData = async configPath => {
     coverageDirectory = 'coverage',
   } = typeof config === 'function' ? await config() : config
   const reportPath = path.resolve(
-    process.cwd(),
+    path.dirname(configPath),
     coverageDirectory,
     'coverage-summary.json',
   )

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,5 +45,5 @@ module.exports = async ({
     applyChanges(configPath, data)
   }
 
-  outputResult(dryRun)
+  outputResult(configPath, dryRun)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,12 +10,15 @@ const outputChanges = require('./outputChanges')
 const outputResult = require('./outputResult')
 
 module.exports = async ({
+  config = false,
   dryRun = false,
   interactive = false,
   margin = 0,
   silent = false,
 } = {}) => {
-  const configPath = path.resolve(process.cwd(), 'jest.config.js')
+  const configPath = config
+    ? path.resolve(process.cwd(), config)
+    : path.resolve(process.cwd(), 'jest.config.js')
 
   const { thresholds, coverages } = await getData(configPath)
   const newThresholds = getNewThresholds(thresholds, coverages, margin)

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,15 +10,13 @@ const outputChanges = require('./outputChanges')
 const outputResult = require('./outputResult')
 
 module.exports = async ({
-  config = false,
+  config = 'jest.config.js',
   dryRun = false,
   interactive = false,
   margin = 0,
   silent = false,
 } = {}) => {
-  const configPath = config
-    ? path.resolve(process.cwd(), config)
-    : path.resolve(process.cwd(), 'jest.config.js')
+  const configPath = path.resolve(process.cwd(), config)
 
   const { thresholds, coverages } = await getData(configPath)
   const newThresholds = getNewThresholds(thresholds, coverages, margin)

--- a/lib/outputResult.js
+++ b/lib/outputResult.js
@@ -1,10 +1,10 @@
 const { yellow } = require('ansi-colors')
 
-const outputResult = dryRun => {
+const outputResult = (configPath, dryRun) => {
   console.log(
     dryRun
-      ? `No changes made to ${yellow('jest.config.js')}. (dry-run mode)`
-      : `Done! Please record the changes to ${yellow('jest.config.js')}.`,
+      ? `No changes made to ${yellow(configPath)}. (dry-run mode)`
+      : `Done! Please record the changes to ${yellow(configPath)}.`,
   )
 }
 


### PR DESCRIPTION
Provide a custom jest config path

> https://github.com/rbardini/jest-it-up/issues/4#issuecomment-756715547 For the custom config path, we could offer the same -c, --config <path> option that [Jest CLI uses](https://jestjs.io/docs/en/cli#--configpath).