### PR TITLE
Support for non-global code coverage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ module.exports = {
       functions: 0,
       lines: 0,
       statements: 0
+    },
+    './src/**/*.module.ts': { // coverage key with pattern
+      branches: 50, // or your current numbers for the patterned threshold key
+      functions: 50,
+      lines: 50,
+      statements: 50
     }
   }
 }
@@ -66,9 +72,17 @@ Options:
   -c, --config <path>          path to a Jest config file (default: 'jest.config.js')
   -m, --margin <margin>        minimum threshold increase (default: 0)
   -t, --tolerance <tolerance>  threshold difference from actual coverage
+  -k, --thresholdKeys <keys>   comma-separated list of threshold keys to consider (default: 'global')
   -i, --interactive            ask for confirmation before applying changes
   -s, --silent                 do not output messages
   -d, --dry-run                process but do not change files
   -v, --version                output the version number
   -h, --help                   display help for command
 ```
+
+jest-it-up only considers the `global` threshold key by default. To update custom threshold keys, you can use the `--thresholdKeys` option when running the script. For example, to update the `global` and `./src/**/*.module.ts` threshold keys, you can run:
+
+```console
+$ jest-it-up --thresholdKeys global,"./src/**/*.module.ts"
+```
+This will update the specified threshold keys (global and custom) and leave others unchanged.

--- a/bin/jest-it-up
+++ b/bin/jest-it-up
@@ -13,6 +13,11 @@ program
     parseFloat,
     0,
   )
+  .option(
+    '-k, --threshold-keys <keys>',
+    `comma-separated list of threshold keys to consider (default: 'global')`,
+    'global',
+  )
   .option('-i, --interactive', 'ask for confirmation before applying changes')
   .option('-s, --silent', 'do not output messages')
   .option('-d, --dry-run', 'process but do not change files')

--- a/lib/__tests__/getChanges.test.js
+++ b/lib/__tests__/getChanges.test.js
@@ -3,6 +3,7 @@ require('ansi-colors').enabled = false
 
 const getChanges = require('../getChanges')
 
+console.warn = jest.fn()
 const configPath = './jest.config.js'
 const getContents = (
   level1 = 'coverageThreshold',
@@ -18,19 +19,26 @@ const getContents = (
   },
 }`
 const getNewThresholds = (
+  level2 = 'global',
   newThresholds = {
     branches: { diff: 70, next: 80, prev: 10 },
     functions: { diff: 50, next: 70, prev: 20 },
     lines: { diff: 30, next: 60, prev: 30 },
     statements: { diff: 10, next: 50, prev: 40 },
   },
-) => newThresholds
+) => ({ [level2]: newThresholds })
 
 jest.mock('fs')
 
+// Mock console.warn
+jest.spyOn(console, 'warn').mockImplementation(() => {})
+beforeEach(() => {
+  console.warn.mockReset()
+})
+
 it('returns the original contents and no changes if no new thresholds', () => {
   const contents = getContents()
-  const newThresholds = getNewThresholds({})
+  const newThresholds = getNewThresholds('global', {})
 
   fs.readFileSync.mockReturnValue(contents)
   const { changes, data } = getChanges(configPath, newThresholds)
@@ -38,18 +46,6 @@ it('returns the original contents and no changes if no new thresholds', () => {
   expect(fs.readFileSync).toHaveBeenCalledTimes(1)
   expect(fs.readFileSync).toHaveBeenCalledWith(configPath, 'utf8')
   expect(changes).toStrictEqual([])
-  expect(data).toMatchInlineSnapshot(`
-    "module.exports = {
-      coverageThreshold: {
-        global: {
-          branches: 10,
-          functions: 20,
-          lines: 30,
-          statements: 40,
-        },
-      },
-    }"
-  `)
   expect(data).toBe(contents)
 })
 
@@ -61,10 +57,10 @@ it('returns the new contents and changes if new thresholds', () => {
   const { changes, data } = getChanges(configPath, newThresholds)
 
   expect(changes).toStrictEqual([
-    'branches    10 → 80    +70',
-    'functions   20 → 70    +50',
-    'lines       30 → 60    +30',
-    'statements  40 → 50    +10',
+    'global branches    10 → 80    +70',
+    'global functions   20 → 70    +50',
+    'global lines       30 → 60    +30',
+    'global statements  40 → 50    +10',
   ])
   expect(data).toMatchInlineSnapshot(`
     "module.exports = {
@@ -89,7 +85,12 @@ it.each([
   'returns the original contents and no changes if no matches #%#',
   (level1, level2) => {
     const contents = getContents(level1, level2)
-    const newThresholds = getNewThresholds()
+    const newThresholds = getNewThresholds(level2, {
+      branches: { diff: 0, next: 10, prev: 10 },
+      functions: { diff: 0, next: 20, prev: 20 },
+      lines: { diff: 0, next: 30, prev: 30 },
+      statements: { diff: 0, next: 40, prev: 40 },
+    })
 
     fs.readFileSync.mockReturnValueOnce(contents)
     const { changes, data } = getChanges(configPath, newThresholds)
@@ -98,3 +99,43 @@ it.each([
     expect(data).toBe(contents)
   },
 )
+
+it('returns changes for an updated custom threshold', () => {
+  fs.readFileSync.mockReturnValue(`
+    module.exports = {
+      coverageThreshold: {
+        global: {
+          branches: 0,
+          functions: 0,
+          lines: 0,
+          statements: 0,
+        },
+        './src/modules/**/*.module.ts': {
+          branches: 50,
+          functions: 60,
+          lines: 70,
+          statements: 80,
+        },
+      },
+    }
+  `)
+
+  const changes = getChanges('./jest.config.js', {
+    './src/modules/**/*.module.ts': {
+      branches: { prev: 50, next: 55, diff: 5 },
+      functions: { prev: 60, next: 65, diff: 5 },
+      lines: { prev: 70, next: 75, diff: 5 },
+      statements: { prev: 80, next: 85, diff: 5 },
+    },
+  })
+
+  expect(changes).toEqual({
+    data: expect.any(String),
+    changes: [
+      './src/modules/**/*.module.ts branches    50 → 55     +5',
+      './src/modules/**/*.module.ts functions   60 → 65     +5',
+      './src/modules/**/*.module.ts lines       70 → 75     +5',
+      './src/modules/**/*.module.ts statements  80 → 85     +5',
+    ],
+  })
+})

--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -34,7 +34,7 @@ it('returns parsed config and report contents', async () => {
     virtual: true,
   })
 
-  const data = await getData(configPath)
+  const data = await getData(configPath, ['global'])
 
   expect(fs.readFileSync).toHaveBeenCalledTimes(1)
   expect(fs.readFileSync).toHaveBeenCalledWith(
@@ -49,16 +49,83 @@ it('returns parsed config and report contents', async () => {
       statements: { pct: 50 },
     },
     thresholds: {
-      branches: 10,
-      functions: 20,
-      lines: 30,
-      statements: 40,
+      global: {
+        branches: 10,
+        functions: 20,
+        lines: 30,
+        statements: 40,
+      },
     },
   })
 })
 
 it('returns parsed async config and report contents', async () => {
   jest.mock('../jest.config.js', () => async () => ({ coverageThreshold }), {
+    virtual: true,
+  })
+
+  const data = await getData(configPath, ['global'])
+
+  expect(fs.readFileSync).toHaveBeenCalledTimes(1)
+  expect(fs.readFileSync).toHaveBeenCalledWith(
+    '/workingDir/coverage/coverage-summary.json',
+    'utf8',
+  )
+  expect(data).toStrictEqual({
+    coverages: {
+      branches: { pct: 80 },
+      functions: { pct: 70 },
+      lines: { pct: 60 },
+      statements: { pct: 50 },
+    },
+    thresholds: {
+      global: {
+        branches: 10,
+        functions: 20,
+        lines: 30,
+        statements: 40,
+      },
+    },
+  })
+})
+
+it('returns parsed config and report contents when a custom coverage directory is specified in the jest config', async () => {
+  jest.mock(
+    '../jest.config.js',
+    () => ({
+      coverageThreshold,
+      coverageDirectory: 'custom/coverage/directory',
+    }),
+    { virtual: true },
+  )
+
+  const data = await getData(configPath, ['global'])
+
+  expect(fs.readFileSync).toHaveBeenCalledTimes(1)
+  expect(fs.readFileSync).toHaveBeenCalledWith(
+    '/workingDir/custom/coverage/directory/coverage-summary.json',
+    'utf8',
+  )
+  expect(data).toStrictEqual({
+    coverages: {
+      branches: { pct: 80 },
+      functions: { pct: 70 },
+      lines: { pct: 60 },
+      statements: { pct: 50 },
+    },
+    thresholds: {
+      global: {
+        branches: 10,
+        functions: 20,
+        lines: 30,
+        statements: 40,
+      },
+    },
+  })
+})
+
+it('returns all threshold objects when no thresholdKeys parameter is provided', async () => {
+  jest.mock('../jest.config.js', () => ({ coverageThreshold }), {
     virtual: true,
   })
 
@@ -77,29 +144,26 @@ it('returns parsed async config and report contents', async () => {
       statements: { pct: 50 },
     },
     thresholds: {
-      branches: 10,
-      functions: 20,
-      lines: 30,
-      statements: 40,
+      global: {
+        branches: 10,
+        functions: 20,
+        lines: 30,
+        statements: 40,
+      },
     },
   })
 })
 
-it('returns parsed config and report contents when a custom coverage directory is specified in the jest config', async () => {
-  jest.mock(
-    '../jest.config.js',
-    () => ({
-      coverageThreshold,
-      coverageDirectory: 'custom/coverage/directory',
-    }),
-    { virtual: true },
-  )
+it('returns an empty thresholds object when an empty thresholdKeys array is provided', async () => {
+  jest.mock('../jest.config.js', () => ({ coverageThreshold }), {
+    virtual: true,
+  })
 
-  const data = await getData(configPath)
+  const data = await getData(configPath, [])
 
   expect(fs.readFileSync).toHaveBeenCalledTimes(1)
   expect(fs.readFileSync).toHaveBeenCalledWith(
-    '/workingDir/custom/coverage/directory/coverage-summary.json',
+    '/workingDir/coverage/coverage-summary.json',
     'utf8',
   )
   expect(data).toStrictEqual({
@@ -109,11 +173,6 @@ it('returns parsed config and report contents when a custom coverage directory i
       lines: { pct: 60 },
       statements: { pct: 50 },
     },
-    thresholds: {
-      branches: 10,
-      functions: 20,
-      lines: 30,
-      statements: 40,
-    },
+    thresholds: {},
   })
 })

--- a/lib/__tests__/getNewThresholds.test.js
+++ b/lib/__tests__/getNewThresholds.test.js
@@ -1,17 +1,19 @@
 const getNewThresholds = require('../getNewThresholds')
 
 it('returns empty object if no thresholds are defined', () => {
-  const newThresholds = getNewThresholds({})
+  const newThresholds = getNewThresholds({}, {}, 0, 0)
 
   expect(newThresholds).toStrictEqual({})
 })
 
-it('returns new thresholds if coverages are higher', () => {
+it('returns new thresholds for nested objects if coverages are higher', () => {
   const thresholds = {
-    branches: 10,
-    functions: 20,
-    lines: 30,
-    statements: 40,
+    global: {
+      branches: 10,
+      functions: 20,
+      lines: 30,
+      statements: 40,
+    },
   }
   const coverages = {
     branches: { pct: 80 },
@@ -30,19 +32,23 @@ it('returns new thresholds if coverages are higher', () => {
   )
 
   expect(newThresholds).toStrictEqual({
-    branches: { diff: 70, next: 80, prev: 10 },
-    functions: { diff: 50, next: 70, prev: 20 },
-    lines: { diff: 30, next: 60, prev: 30 },
-    statements: { diff: 10, next: 50, prev: 40 },
+    global: {
+      branches: { diff: 70, next: 80, prev: 10 },
+      functions: { diff: 50, next: 70, prev: 20 },
+      lines: { diff: 30, next: 60, prev: 30 },
+      statements: { diff: 10, next: 50, prev: 40 },
+    },
   })
 })
 
-it('only returns new thresholds if coverages are above the margin', () => {
+it('only returns new thresholds for nested objects if coverages are above the margin', () => {
   const thresholds = {
-    branches: 10,
-    functions: 20,
-    lines: 30,
-    statements: 40,
+    global: {
+      branches: 10,
+      functions: 20,
+      lines: 30,
+      statements: 40,
+    },
   }
   const coverages = {
     branches: { pct: 80 },
@@ -61,17 +67,21 @@ it('only returns new thresholds if coverages are above the margin', () => {
   )
 
   expect(newThresholds).toStrictEqual({
-    branches: { diff: 70, next: 80, prev: 10 },
-    functions: { diff: 50, next: 70, prev: 20 },
+    global: {
+      branches: { diff: 70, next: 80, prev: 10 },
+      functions: { diff: 50, next: 70, prev: 20 },
+    },
   })
 })
 
-it('should return new thresholds if coverage - tolerance is higher than the current threshold', () => {
+it('should return new thresholds for nested objects if coverage - tolerance is higher than the current threshold', () => {
   const thresholds = {
-    branches: 10,
-    functions: 20,
-    lines: 30,
-    statements: 40,
+    global: {
+      branches: 10,
+      functions: 20,
+      lines: 30,
+      statements: 40,
+    },
   }
   const coverages = {
     branches: { pct: 80 },
@@ -90,19 +100,23 @@ it('should return new thresholds if coverage - tolerance is higher than the curr
   )
 
   expect(newThresholds).toStrictEqual({
-    branches: { diff: 60, next: 70, prev: 10 },
-    functions: { diff: 40, next: 60, prev: 20 },
-    lines: { diff: 20, next: 50, prev: 30 },
-    statements: { diff: 0, next: 40, prev: 40 },
+    global: {
+      branches: { diff: 60, next: 70, prev: 10 },
+      functions: { diff: 40, next: 60, prev: 20 },
+      lines: { diff: 20, next: 50, prev: 30 },
+      statements: { diff: 0, next: 40, prev: 40 },
+    },
   })
 })
 
-it('should not return new thresholds if coverage - tolerance is lower than the current threshold', () => {
+it('should not return new thresholds for nested objects if coverage - tolerance is lower than the current threshold', () => {
   const thresholds = {
-    branches: 10,
-    functions: 20,
-    lines: 30,
-    statements: 40,
+    global: {
+      branches: 10,
+      functions: 20,
+      lines: 30,
+      statements: 40,
+    },
   }
   const coverages = {
     branches: { pct: 80 },
@@ -120,5 +134,7 @@ it('should not return new thresholds if coverage - tolerance is lower than the c
     tolerance,
   )
 
-  expect(newThresholds).toStrictEqual({})
+  expect(newThresholds).toStrictEqual({
+    global: {},
+  })
 })

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -1,5 +1,4 @@
 const confirm = require('@inquirer/confirm')
-
 const applyChanges = require('../applyChanges')
 const getChanges = require('../getChanges')
 const getData = require('../getData')
@@ -31,10 +30,16 @@ it('runs with with default options', async () => {
   await jestItUp()
 
   expect(getData).toHaveBeenCalledTimes(1)
-  expect(getData).toHaveBeenCalledWith('/workingDir/jest.config.js')
+  expect(getData).toHaveBeenCalledWith('/workingDir/jest.config.js', ['global'])
 
   expect(getNewThresholds).toHaveBeenCalledTimes(1)
-  expect(getNewThresholds).toHaveBeenCalledWith('thresholds', 'coverages', 0, 0)
+  expect(getNewThresholds).toHaveBeenCalledWith(
+    'thresholds',
+    'coverages',
+    0,
+    0,
+    ['global'],
+  )
 
   expect(getChanges).toHaveBeenCalledTimes(1)
   expect(getChanges).toHaveBeenCalledWith(
@@ -76,6 +81,7 @@ it('runs with custom margin', async () => {
     'coverages',
     10,
     0,
+    ['global'],
   )
 })
 
@@ -127,7 +133,9 @@ it('runs with custom config', async () => {
   await jestItUp({ config: './customDir/jest.config.js' })
 
   expect(getData).toHaveBeenCalledTimes(1)
-  expect(getData).toHaveBeenCalledWith('/workingDir/customDir/jest.config.js')
+  expect(getData).toHaveBeenCalledWith('/workingDir/customDir/jest.config.js', [
+    'global',
+  ])
 })
 
 it('runs with custom tolerance', async () => {
@@ -139,5 +147,6 @@ it('runs with custom tolerance', async () => {
     'coverages',
     0,
     10,
+    ['global'],
   )
 })

--- a/lib/getChanges.js
+++ b/lib/getChanges.js
@@ -3,24 +3,33 @@ const { dim, green } = require('ansi-colors')
 
 const getChanges = (configPath, newThresholds) =>
   Object.entries(newThresholds).reduce(
-    (acc, [type, { prev, next, diff }]) => {
-      const newData = acc.data.replace(
-        new RegExp(
-          `(?<=coverageThreshold:.+?global:.+?${type}:\\s*)\\d*\\.?\\d+`,
-          's',
-        ),
-        next,
-      )
+    (acc, [key, newValues]) => {
+      const isNewKey = key !== 'global'
+      const thresholdKey = isNewKey
+        ? `'${key.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')}'`
+        : key
+      const keyPrefix = isNewKey ? `^\\s*` : ''
 
-      if (acc.data !== newData) {
-        acc.data = newData
-
-        acc.changes.push(
-          `${type.padEnd(12)}${dim(prev)} → ${next} ${green(
-            `+${diff}`.padStart(6),
-          )}`,
+      Object.entries(newValues).forEach(([type, { prev, next, diff }]) => {
+        const regex = new RegExp(
+          `(?<=${keyPrefix}${thresholdKey}:\\s*{[^}]*${type}:\\s*)\\d*\\.?\\d+(?=,\\s*\\n\\s*${
+            type === 'statements' ? '}' : ''
+          })`,
+          'ms',
         )
-      }
+
+        const newData = acc.data.replace(regex, next)
+
+        if (acc.data !== newData) {
+          acc.data = newData
+
+          acc.changes.push(
+            `${key} ${type.padEnd(12)}${dim(prev)} → ${next} ${green(
+              `+${diff}`.padStart(6),
+            )}`,
+          )
+        }
+      })
 
       return acc
     },

--- a/lib/getData.js
+++ b/lib/getData.js
@@ -1,12 +1,16 @@
 const fs = require('fs')
 const path = require('path')
 
-const getData = async configPath => {
+const getData = async (configPath, thresholdKeys = ['global']) => {
   const config = require(configPath)
-  const {
-    coverageThreshold: { global: thresholds },
-    coverageDirectory = 'coverage',
-  } = typeof config === 'function' ? await config() : config
+  const { coverageThreshold, coverageDirectory = 'coverage' } =
+    typeof config === 'function' ? await config() : config
+
+  const thresholds = thresholdKeys.reduce((acc, key) => {
+    acc[key] = coverageThreshold[key]
+    return acc
+  }, {})
+
   const reportPath = path.resolve(
     path.dirname(configPath),
     coverageDirectory,

--- a/lib/getNewThresholds.js
+++ b/lib/getNewThresholds.js
@@ -1,18 +1,25 @@
 const getNewThresholds = (thresholds, coverages, margin, tolerance) =>
-  Object.entries(thresholds).reduce((acc, [type, threshold]) => {
-    const { pct: coverage } = coverages[type]
+  Object.entries(thresholds).reduce((acc, [key, nestedThresholds]) => {
+    acc[key] = Object.entries(nestedThresholds).reduce(
+      (nestedAcc, [type, threshold]) => {
+        const { pct: coverage } = coverages[type]
 
-    const desiredCoverage = coverage - tolerance
+        const desiredCoverage = coverage - tolerance
 
-    // Only update threshold if new coverage is higher than
-    // current threshold + margin
-    if (desiredCoverage >= threshold + margin) {
-      acc[type] = {
-        prev: threshold,
-        next: desiredCoverage,
-        diff: +(desiredCoverage - threshold).toFixed(2),
-      }
-    }
+        // Only update threshold if new coverage is higher than
+        // current threshold + margin
+        if (desiredCoverage >= threshold + margin) {
+          nestedAcc[type] = {
+            prev: threshold,
+            next: desiredCoverage,
+            diff: +(desiredCoverage - threshold).toFixed(2),
+          }
+        }
+
+        return nestedAcc
+      },
+      {},
+    )
 
     return acc
   }, {})

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,15 +16,22 @@ module.exports = async ({
   margin = 0,
   tolerance = 0,
   silent = false,
+  thresholdKeys = 'global',
 } = {}) => {
+  const thresholdKeysArray = thresholdKeys.split(',')
   const configPath = path.resolve(process.cwd(), config)
 
-  const { thresholds, coverages } = await getData(configPath)
+  const { thresholds, coverages } = await getData(
+    configPath,
+    thresholdKeysArray,
+  )
+
   const newThresholds = getNewThresholds(
     thresholds,
     coverages,
     margin,
     tolerance,
+    thresholdKeysArray,
   )
   const { changes, data } = getChanges(configPath, newThresholds)
 

--- a/lib/outputChanges.js
+++ b/lib/outputChanges.js
@@ -12,7 +12,9 @@ const outputChanges = (changes, dryRun) => {
   )
 
   console.log()
-  changes.forEach(change => console.log(` ${change}`))
+  changes.forEach(change => {
+    return console.log(` ${change}`)
+  })
   console.log()
 }
 


### PR DESCRIPTION
This PR adds support for non-global code coverage thresholds in the form of `threshold-keys`, which should resolve #13.