### PR TITLE
feat(precision): add `-p, --precision` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --save-dev jest-it-up
 
 ## Usage
 
-jest-it-up exposes a standalone CLI tool (see [options](#options)), but you most likelly want to use it in a post-test script.
+jest-it-up exposes a standalone CLI tool (see [options](#options)), but you most likely want to use it in a post-test script.
 
 Within `package.json`:
 
@@ -70,5 +70,6 @@ Options:
   -s, --silent                 do not output messages
   -d, --dry-run                process but do not change files
   -v, --version                output the version number
+  -p, --precision              number of threshold decimal places to persist
   -h, --help                   display help for command
 ```

--- a/bin/jest-it-up
+++ b/bin/jest-it-up
@@ -17,8 +17,10 @@ program
   .option('-s, --silent', 'do not output messages')
   .option('-d, --dry-run', 'process but do not change files')
   .option(
-    '-w, --whole-number',
-    'round coverage thresholds down to whole a whole number',
+    '-p, --precision <digits>',
+    'number of threshold decimal places to persist',
+    parseInt,
+    2,
   )
   .version(version, '-v, --version')
   .parse(process.argv)

--- a/bin/jest-it-up
+++ b/bin/jest-it-up
@@ -16,6 +16,10 @@ program
   .option('-i, --interactive', 'ask for confirmation before applying changes')
   .option('-s, --silent', 'do not output messages')
   .option('-d, --dry-run', 'process but do not change files')
+  .option(
+    '-w, --whole-number',
+    'round coverage thresholds down to whole a whole number',
+  )
   .version(version, '-v, --version')
   .parse(process.argv)
 

--- a/lib/__tests__/getNewThresholds.test.js
+++ b/lib/__tests__/getNewThresholds.test.js
@@ -21,12 +21,14 @@ it('returns new thresholds if coverages are higher', () => {
   }
   const margin = 0
   const tolerance = 0
+  const precision = 2
 
   const newThresholds = getNewThresholds(
     thresholds,
     coverages,
     margin,
     tolerance,
+    precision,
   )
 
   expect(newThresholds).toStrictEqual({
@@ -52,17 +54,18 @@ it('only returns new thresholds if coverages are above the margin', () => {
   }
   const margin = 50
   const tolerance = 0
+  const precision = 2
 
   const newThresholds = getNewThresholds(
     thresholds,
     coverages,
     margin,
     tolerance,
+    precision,
   )
 
   expect(newThresholds).toStrictEqual({
     branches: { diff: 70, next: 80, prev: 10 },
-    functions: { diff: 50, next: 70, prev: 20 },
   })
 })
 
@@ -81,19 +84,20 @@ it('should return new thresholds if coverage - tolerance is higher than the curr
   }
   const margin = 0
   const tolerance = 10
+  const precision = 2
 
   const newThresholds = getNewThresholds(
     thresholds,
     coverages,
     margin,
     tolerance,
+    precision,
   )
 
   expect(newThresholds).toStrictEqual({
     branches: { diff: 60, next: 70, prev: 10 },
     functions: { diff: 40, next: 60, prev: 20 },
     lines: { diff: 20, next: 50, prev: 30 },
-    statements: { diff: 0, next: 40, prev: 40 },
   })
 })
 
@@ -112,18 +116,53 @@ it('should not return new thresholds if coverage - tolerance is lower than the c
   }
   const margin = 0
   const tolerance = 100
+  const precision = 2
 
   const newThresholds = getNewThresholds(
     thresholds,
     coverages,
     margin,
     tolerance,
+    precision,
   )
 
   expect(newThresholds).toStrictEqual({})
 })
 
-it('should return new thresholds rounded down as a whole number if the whole number flag is set', () => {
+it('should return new thresholds with a precision if set', () => {
+  const thresholds = {
+    branches: 10,
+    functions: 20,
+    lines: 30,
+    statements: 40,
+  }
+  const coverages = {
+    branches: { pct: 80.63 },
+    functions: { pct: 70.15 },
+    lines: { pct: 60.25 },
+    statements: { pct: 50.89 },
+  }
+  const margin = 0
+  const tolerance = 0
+  const precision = 1
+
+  const newThresholds = getNewThresholds(
+    thresholds,
+    coverages,
+    margin,
+    tolerance,
+    precision,
+  )
+
+  expect(newThresholds).toStrictEqual({
+    branches: { diff: 70.6, next: 80.6, prev: 10 },
+    functions: { diff: 50.1, next: 70.1, prev: 20 },
+    lines: { diff: 30.2, next: 60.2, prev: 30 },
+    statements: { diff: 10.8, next: 50.8, prev: 40 },
+  })
+})
+
+it('should return new thresholds be a whole number if precision is set to 0', () => {
   const thresholds = {
     branches: 10,
     functions: 20,
@@ -137,21 +176,21 @@ it('should return new thresholds rounded down as a whole number if the whole num
     statements: { pct: 50.89 },
   }
   const margin = 0
-  const tolerance = 10
-  const wholeNumber = true
+  const tolerance = 0
+  const precision = 0
 
   const newThresholds = getNewThresholds(
     thresholds,
     coverages,
     margin,
     tolerance,
-    wholeNumber
+    precision,
   )
 
   expect(newThresholds).toStrictEqual({
-    branches: { diff: 60.6, next: 70, prev: 10 },
-    functions: { diff: 40.1, next: 60, prev: 20 },
-    lines: { diff: 20.25, next: 50, prev: 30 },
-    statements: { diff: 0.89, next: 40, prev: 40 },
+    branches: { diff: 70, next: 80, prev: 10 },
+    functions: { diff: 50, next: 70, prev: 20 },
+    lines: { diff: 30, next: 60, prev: 30 },
+    statements: { diff: 10, next: 50, prev: 40 },
   })
 })

--- a/lib/__tests__/getNewThresholds.test.js
+++ b/lib/__tests__/getNewThresholds.test.js
@@ -122,3 +122,36 @@ it('should not return new thresholds if coverage - tolerance is lower than the c
 
   expect(newThresholds).toStrictEqual({})
 })
+
+it('should return new thresholds rounded down as a whole number if the whole number flag is set', () => {
+  const thresholds = {
+    branches: 10,
+    functions: 20,
+    lines: 30,
+    statements: 40,
+  }
+  const coverages = {
+    branches: { pct: 80.6 },
+    functions: { pct: 70.1 },
+    lines: { pct: 60.25 },
+    statements: { pct: 50.89 },
+  }
+  const margin = 0
+  const tolerance = 10
+  const wholeNumber = true
+
+  const newThresholds = getNewThresholds(
+    thresholds,
+    coverages,
+    margin,
+    tolerance,
+    wholeNumber
+  )
+
+  expect(newThresholds).toStrictEqual({
+    branches: { diff: 60.6, next: 70, prev: 10 },
+    functions: { diff: 40.1, next: 60, prev: 20 },
+    lines: { diff: 20.25, next: 50, prev: 30 },
+    statements: { diff: 0.89, next: 40, prev: 40 },
+  })
+})

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -34,7 +34,13 @@ it('runs with with default options', async () => {
   expect(getData).toHaveBeenCalledWith('/workingDir/jest.config.js')
 
   expect(getNewThresholds).toHaveBeenCalledTimes(1)
-  expect(getNewThresholds).toHaveBeenCalledWith('thresholds', 'coverages', 0, 0)
+  expect(getNewThresholds).toHaveBeenCalledWith(
+    'thresholds',
+    'coverages',
+    0,
+    0,
+    2,
+  )
 
   expect(getChanges).toHaveBeenCalledTimes(1)
   expect(getChanges).toHaveBeenCalledWith(
@@ -76,6 +82,7 @@ it('runs with custom margin', async () => {
     'coverages',
     10,
     0,
+    2,
   )
 })
 
@@ -139,5 +146,19 @@ it('runs with custom tolerance', async () => {
     'coverages',
     0,
     10,
+    2,
+  )
+})
+
+it('runs with custom precision', async () => {
+  await jestItUp({ precision: 0, tolerance: 10 })
+
+  expect(getNewThresholds).toHaveBeenCalledTimes(1)
+  expect(getNewThresholds).toHaveBeenCalledWith(
+    'thresholds',
+    'coverages',
+    0,
+    10,
+    0,
   )
 })

--- a/lib/getNewThresholds.js
+++ b/lib/getNewThresholds.js
@@ -1,16 +1,24 @@
-const getNewThresholds = (thresholds, coverages, margin, tolerance, wholeNumber) =>
+const getNewThresholds = (
+  thresholds,
+  coverages,
+  margin,
+  tolerance,
+  precision,
+) =>
   Object.entries(thresholds).reduce((acc, [type, threshold]) => {
     const { pct: coverage } = coverages[type]
 
     const desiredCoverage = coverage - tolerance
+    const factor = Math.pow(10, precision)
+    const nextCoverage = Math.trunc(desiredCoverage * factor) / factor
 
     // Only update threshold if new coverage is higher than
     // current threshold + margin
-    if (desiredCoverage >= threshold + margin) {
+    if (nextCoverage > threshold + margin) {
       acc[type] = {
         prev: threshold,
-        next: wholeNumber ? Math.floor(desiredCoverage) : desiredCoverage,
-        diff: +(desiredCoverage - threshold).toFixed(2),
+        next: nextCoverage,
+        diff: +(nextCoverage - threshold).toFixed(2),
       }
     }
 

--- a/lib/getNewThresholds.js
+++ b/lib/getNewThresholds.js
@@ -1,4 +1,4 @@
-const getNewThresholds = (thresholds, coverages, margin, tolerance) =>
+const getNewThresholds = (thresholds, coverages, margin, tolerance, wholeNumber) =>
   Object.entries(thresholds).reduce((acc, [type, threshold]) => {
     const { pct: coverage } = coverages[type]
 
@@ -9,7 +9,7 @@ const getNewThresholds = (thresholds, coverages, margin, tolerance) =>
     if (desiredCoverage >= threshold + margin) {
       acc[type] = {
         prev: threshold,
-        next: desiredCoverage,
+        next: wholeNumber ? Math.floor(desiredCoverage) : desiredCoverage,
         diff: +(desiredCoverage - threshold).toFixed(2),
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ module.exports = async ({
   margin = 0,
   tolerance = 0,
   silent = false,
-  wholeNumber = false,
+  precision = 2,
 } = {}) => {
   const configPath = path.resolve(process.cwd(), config)
 
@@ -26,7 +26,7 @@ module.exports = async ({
     coverages,
     margin,
     tolerance,
-    wholeNumber
+    precision,
   )
   const { changes, data } = getChanges(configPath, newThresholds)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ module.exports = async ({
   margin = 0,
   tolerance = 0,
   silent = false,
+  wholeNumber = false,
 } = {}) => {
   const configPath = path.resolve(process.cwd(), config)
 
@@ -25,6 +26,7 @@ module.exports = async ({
     coverages,
     margin,
     tolerance,
+    wholeNumber
   )
   const { changes, data } = getChanges(configPath, newThresholds)
 


### PR DESCRIPTION
We have an issue where we want to bump the coverage but don't want to bump it by 2 decimal places. We want to bump it by a whole number. so if our margin is 1 and the increase is 1.65% we want to go from 40 -> 41 instead of 41.65.

I think this also addresses the issues been spoken about here - https://github.com/rbardini/jest-it-up/issues/17

Also please feel free to rip this apart and tell me if you'd like changes. it would be great to get this in :)