### PR TITLE
fix(config): resolve `<rootDir>` to `.` in `coverageDirectory`

### DIFF
--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -128,8 +128,6 @@ it('resolves <rootDir> as current directory', async () => {
     { virtual: true },
   )
 
-  const data = await getData(configPath)
-
   expect(fs.readFileSync).toHaveBeenCalledTimes(1)
   expect(fs.readFileSync).toHaveBeenCalledWith(
     `/workingDir/custom/coverage/directory/coverage-summary.json`,

--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -117,3 +117,22 @@ it('returns parsed config and report contents when a custom coverage directory i
     },
   })
 })
+
+it('resolves <rootDir> as current directory', async () => {
+  jest.mock(
+    '../jest.config.js',
+    () => ({
+      coverageThreshold,
+      coverageDirectory: '<rootDir>/custom/coverage/directory',
+    }),
+    { virtual: true },
+  )
+
+  const data = await getData(configPath)
+
+  expect(fs.readFileSync).toHaveBeenCalledTimes(1)
+  expect(fs.readFileSync).toHaveBeenCalledWith(
+    `/workingDir/custom/coverage/directory/coverage-summary.json`,
+    'utf8',
+  )
+})

--- a/lib/__tests__/getData.test.js
+++ b/lib/__tests__/getData.test.js
@@ -128,6 +128,8 @@ it('resolves <rootDir> as current directory', async () => {
     { virtual: true },
   )
 
+  await getData(configPath)
+
   expect(fs.readFileSync).toHaveBeenCalledTimes(1)
   expect(fs.readFileSync).toHaveBeenCalledWith(
     `/workingDir/custom/coverage/directory/coverage-summary.json`,

--- a/lib/getData.js
+++ b/lib/getData.js
@@ -7,7 +7,10 @@ const getData = async configPath => {
     coverageThreshold: { global: thresholds },
     coverageDirectory = 'coverage',
   } = typeof config === 'function' ? await config() : config
-  const normalizedCoverageDirectory = coverageDirectory.replace('<rootDir>', path.dirname(configPath))
+  const normalizedCoverageDirectory = coverageDirectory.replace(
+    '<rootDir>',
+    path.dirname(configPath),
+  )
   const reportPath = path.resolve(
     normalizedCoverageDirectory,
     'coverage-summary.json',

--- a/lib/getData.js
+++ b/lib/getData.js
@@ -7,12 +7,9 @@ const getData = async configPath => {
     coverageThreshold: { global: thresholds },
     coverageDirectory = 'coverage',
   } = typeof config === 'function' ? await config() : config
-  const normalizedCoverageDirectory = coverageDirectory.replace(
-    '<rootDir>',
-    path.dirname(configPath),
-  )
   const reportPath = path.resolve(
-    normalizedCoverageDirectory,
+    path.dirname(configPath),
+    coverageDirectory.replace('<rootDir>', '.'),
     'coverage-summary.json',
   )
   const { total: coverages } = JSON.parse(fs.readFileSync(reportPath, 'utf8'))

--- a/lib/getData.js
+++ b/lib/getData.js
@@ -7,9 +7,9 @@ const getData = async configPath => {
     coverageThreshold: { global: thresholds },
     coverageDirectory = 'coverage',
   } = typeof config === 'function' ? await config() : config
+  const normalizedCoverageDirectory = coverageDirectory.replace('<rootDir>', path.dirname(configPath))
   const reportPath = path.resolve(
-    path.dirname(configPath),
-    coverageDirectory,
+    normalizedCoverageDirectory,
     'coverage-summary.json',
   )
   const { total: coverages } = JSON.parse(fs.readFileSync(reportPath, 'utf8'))


### PR DESCRIPTION
Jest allows root directory `<rootDir>` string token to be specified for path configurations.
This fix allows this variable to be resolved into `path.dirname(configPath)`.

Fixes #22