### PR TITLE
adding option to set max threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,6 @@ Options:
   -d, --dry-run                process but do not change files
   -v, --version                output the version number
   -p, --precision              number of threshold decimal places to persist
+  ---max-threshold             max value to update the threshold
   -h, --help                   display help for command
 ```

--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ $ jest-it-up --help
 Usage: jest-it-up [options]
 
 Options:
-  -c, --config <path>          path to a Jest config file (default: 'jest.config.js')
-  -m, --margin <margin>        minimum threshold increase (default: 0)
-  -t, --tolerance <tolerance>  threshold difference from actual coverage
-  -i, --interactive            ask for confirmation before applying changes
-  -s, --silent                 do not output messages
-  -d, --dry-run                process but do not change files
-  -v, --version                output the version number
-  -p, --precision              number of threshold decimal places to persist
-  ---max-threshold             max value to update the threshold
-  -h, --help                   display help for command
+  -c, --config <path>             path to a Jest config file (default: "jest.config.js")
+  -m, --margin <margin>           minimum threshold increase (default: 0)
+  -t, --tolerance <tolerance>     threshold difference from actual coverage (default: 0)
+  -i, --interactive               ask for confirmation before applying changes
+  -s, --silent                    do not output messages
+  -d, --dry-run                   process but do not change files
+  -T --target-threshold <target>  target threshold to reach (default: 100)
+  -p, --precision <digits>        number of threshold decimal places to persist (default: 2)
+  -v, --version                   output the version number
+  -h, --help                      display help for command
 ```

--- a/bin/jest-it-up
+++ b/bin/jest-it-up
@@ -17,8 +17,8 @@ program
   .option('-s, --silent', 'do not output messages')
   .option('-d, --dry-run', 'process but do not change files')
   .option(
-    '--max-threshold <max>',
-    'max value to update the threshold',
+    '-T --target-threshold <target>',
+    'target threshold to reach',
     parseFloat,
     100,
   )

--- a/bin/jest-it-up
+++ b/bin/jest-it-up
@@ -17,6 +17,12 @@ program
   .option('-s, --silent', 'do not output messages')
   .option('-d, --dry-run', 'process but do not change files')
   .option(
+    '--max-threshold <max>',
+    'max value to update the threshold',
+    parseFloat,
+    100,
+  )
+  .option(
     '-p, --precision <digits>',
     'number of threshold decimal places to persist',
     parseInt,

--- a/lib/__tests__/getNewThresholds.test.js
+++ b/lib/__tests__/getNewThresholds.test.js
@@ -195,9 +195,9 @@ it('should return new thresholds be a whole number if precision is set to 0', ()
   })
 })
 
-it('should return new thresholds with max threshold below 100', () => {
+it('should return new thresholds with target threshold of 65', () => {
   const thresholds = {
-    branches: 10,
+    branches: 65,
     functions: 20,
     lines: 30,
     statements: 40,
@@ -211,7 +211,7 @@ it('should return new thresholds with max threshold below 100', () => {
   const margin = 0
   const tolerance = 0
   const precision = 2
-  const maxThreshold = 65
+  const targetThreshold = 65
 
   const newThresholds = getNewThresholds(
     thresholds,
@@ -219,11 +219,10 @@ it('should return new thresholds with max threshold below 100', () => {
     margin,
     tolerance,
     precision,
-    maxThreshold,
+    targetThreshold,
   )
 
   expect(newThresholds).toStrictEqual({
-    branches: { diff: 55, next: 65, prev: 10 },
     functions: { diff: 45, next: 65, prev: 20 },
     lines: { diff: 30, next: 60, prev: 30 },
     statements: { diff: 10, next: 50, prev: 40 },

--- a/lib/__tests__/getNewThresholds.test.js
+++ b/lib/__tests__/getNewThresholds.test.js
@@ -194,3 +194,38 @@ it('should return new thresholds be a whole number if precision is set to 0', ()
     statements: { diff: 10, next: 50, prev: 40 },
   })
 })
+
+it('should return new thresholds with max threshold below 100', () => {
+  const thresholds = {
+    branches: 10,
+    functions: 20,
+    lines: 30,
+    statements: 40,
+  }
+  const coverages = {
+    branches: { pct: 80 },
+    functions: { pct: 70 },
+    lines: { pct: 60 },
+    statements: { pct: 50 },
+  }
+  const margin = 0
+  const tolerance = 0
+  const precision = 2
+  const maxThreshold = 65
+
+  const newThresholds = getNewThresholds(
+    thresholds,
+    coverages,
+    margin,
+    tolerance,
+    precision,
+    maxThreshold,
+  )
+
+  expect(newThresholds).toStrictEqual({
+    branches: { diff: 55, next: 65, prev: 10 },
+    functions: { diff: 45, next: 65, prev: 20 },
+    lines: { diff: 30, next: 60, prev: 30 },
+    statements: { diff: 10, next: 50, prev: 40 },
+  })
+})

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -40,6 +40,7 @@ it('runs with with default options', async () => {
     0,
     0,
     2,
+    100,
   )
 
   expect(getChanges).toHaveBeenCalledTimes(1)
@@ -83,6 +84,7 @@ it('runs with custom margin', async () => {
     10,
     0,
     2,
+    100,
   )
 })
 
@@ -147,6 +149,7 @@ it('runs with custom tolerance', async () => {
     0,
     10,
     2,
+    100,
   )
 })
 
@@ -160,5 +163,20 @@ it('runs with custom precision', async () => {
     0,
     10,
     0,
+    100,
+  )
+})
+
+it('runs with custom max-threshold', async () => {
+  await jestItUp({ maxThreshold: 80 })
+
+  expect(getNewThresholds).toHaveBeenCalledTimes(1)
+  expect(getNewThresholds).toHaveBeenCalledWith(
+    'thresholds',
+    'coverages',
+    0,
+    0,
+    2,
+    80,
   )
 })

--- a/lib/__tests__/index.test.js
+++ b/lib/__tests__/index.test.js
@@ -167,8 +167,8 @@ it('runs with custom precision', async () => {
   )
 })
 
-it('runs with custom max-threshold', async () => {
-  await jestItUp({ maxThreshold: 80 })
+it('runs with custom target-threshold', async () => {
+  await jestItUp({ targetThreshold: 80 })
 
   expect(getNewThresholds).toHaveBeenCalledTimes(1)
   expect(getNewThresholds).toHaveBeenCalledWith(

--- a/lib/getNewThresholds.js
+++ b/lib/getNewThresholds.js
@@ -4,6 +4,7 @@ const getNewThresholds = (
   margin,
   tolerance,
   precision,
+  maxThreshold,
 ) =>
   Object.entries(thresholds).reduce((acc, [type, threshold]) => {
     const { pct: coverage } = coverages[type]
@@ -15,10 +16,11 @@ const getNewThresholds = (
     // Only update threshold if new coverage is higher than
     // current threshold + margin
     if (nextCoverage > threshold + margin) {
+      const next = Math.min(nextCoverage, maxThreshold ?? 100)
       acc[type] = {
         prev: threshold,
-        next: nextCoverage,
-        diff: +(nextCoverage - threshold).toFixed(2),
+        next,
+        diff: +(next - threshold).toFixed(2),
       }
     }
 

--- a/lib/getNewThresholds.js
+++ b/lib/getNewThresholds.js
@@ -4,7 +4,7 @@ const getNewThresholds = (
   margin,
   tolerance,
   precision,
-  maxThreshold,
+  targetThreshold = 100,
 ) =>
   Object.entries(thresholds).reduce((acc, [type, threshold]) => {
     const { pct: coverage } = coverages[type]
@@ -15,8 +15,8 @@ const getNewThresholds = (
 
     // Only update threshold if new coverage is higher than
     // current threshold + margin
-    if (nextCoverage > threshold + margin) {
-      const next = Math.min(nextCoverage, maxThreshold ?? 100)
+    if (nextCoverage > threshold + margin && threshold < targetThreshold) {
+      const next = Math.min(nextCoverage, targetThreshold ?? 100)
       acc[type] = {
         prev: threshold,
         next,

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ module.exports = async ({
   tolerance = 0,
   silent = false,
   precision = 2,
-  maxThreshold = 100,
+  targetThreshold = 100,
 } = {}) => {
   const configPath = path.resolve(process.cwd(), config)
 
@@ -28,7 +28,7 @@ module.exports = async ({
     margin,
     tolerance,
     precision,
-    maxThreshold,
+    targetThreshold,
   )
   const { changes, data } = getChanges(configPath, newThresholds)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ module.exports = async ({
   tolerance = 0,
   silent = false,
   precision = 2,
+  maxThreshold = 100,
 } = {}) => {
   const configPath = path.resolve(process.cwd(), config)
 
@@ -27,6 +28,7 @@ module.exports = async ({
     margin,
     tolerance,
     precision,
+    maxThreshold,
   )
   const { changes, data } = getChanges(configPath, newThresholds)
 


### PR DESCRIPTION
Hi there,

In our org we would like to set a max value for coverage. Meaning if the coverage is above that value, we no longer bump the thresholds. 
This ensures that we set realistic targets that we don't have to adjust downwards all the time.
This would also fix issue https://github.com/rbardini/jest-it-up/issues/21

This PR adds this ability to jest-it-up.

How it works:

current:
```
coverageThreshold: {
  global: {
    statements: 60,
    branches: 12,
    functions: 32,
    lines: 34,
  },
}
```
actual:
```
coverageThreshold: {
  global: {
    statements: 62,
    branches: 45,
    functions: 70,
    lines: 55,
  },
}
```

`npx jest-it-up --max-threshold 60`

new: 
```
coverageThreshold: {
  global: {
    statements: 60,
    branches: 45,
    functions: 60,
    lines: 55,
  },
}
```

please review it and consider merging it, if you think it adds value.